### PR TITLE
Updates so user can deploy their own personal token

### DIFF
--- a/app/assets/v2/js/board.js
+++ b/app/assets/v2/js/board.js
@@ -329,12 +329,12 @@ Vue.mixin({
 
       // We currently have DAI addresses hardcoded, so right now pTokens only support
       // being priced in DAI
-      let tokenAddress;
+      let purchaseTokenAddress;
 
       if (document.web3network === 'rinkeby') {
-        tokenAddress = '0x6A9865aDE2B6207dAAC49f8bCba9705dEB0B0e6D';
+        purchaseTokenAddress = '0x6A9865aDE2B6207dAAC49f8bCba9705dEB0B0e6D';
       } else if (document.web3network === 'mainnet') {
-        tokenAddress = '0x6B175474E89094C44Da98b954EedeAC495271d0F';
+        purchaseTokenAddress = '0x6B175474E89094C44Da98b954EedeAC495271d0F';
       } else {
         _alert('Unsupported network', 'error');
         return;
@@ -349,7 +349,7 @@ Vue.mixin({
         newPToken.symbol,
         web3.utils.toWei(String(newPToken.price)),
         web3.utils.toWei(String(newPToken.supply)),
-        tokenAddress
+        purchaseTokenAddress
       ).send({
         from: user
       }).on('transactionHash', function(transactionHash) {

--- a/app/assets/v2/js/board.js
+++ b/app/assets/v2/js/board.js
@@ -354,6 +354,7 @@ Vue.mixin({
         from: user
       }).on('transactionHash', function(transactionHash) {
         // Save to database
+        indicateMetamaskPopup(true);
         create_ptoken(
           newPToken.name,
           newPToken.symbol,
@@ -367,6 +368,7 @@ Vue.mixin({
         vm.user_has_token = true;
         console.log('Token Created!');
       }).on('error', function(err) {
+        indicateMetamaskPopup(true);
         this.handleError(err);
       });
     },

--- a/app/assets/v2/js/board.js
+++ b/app/assets/v2/js/board.js
@@ -1,3 +1,7 @@
+// Personal token constants
+// Note that this address is also duplicated in profile_tokens.js
+const factoryAddress = '0x80D50970599E33d0D5D436A649C25b729666A015';
+
 let contributorBounties = {};
 let pTokens = {};
 let bounties = {};
@@ -318,20 +322,34 @@ Vue.mixin({
     async deployAndSaveToken() {
       const vm = this;
 
+      if (!web3) {
+        _alert('Please connect a wallet', 'error');
+      }
       [user] = await web3.eth.getAccounts();
-      // TODO: This is a deterministic localhost address. Should be an env variable for rinkeby/mainnet.
-      const factoryAddress = '0x7bE324A085389c82202BEb90D979d097C5b3f2E8';
-      const mockDaiAddress = '0x6b67DD1542ef11153141037734D21E7Cbd7D9817';
+
+      // We currently have DAI addresses hardcoded, so right now pTokens only support
+      // being priced in DAI
+      let tokenAddress;
+
+      if (document.web3network === 'rinkeby') {
+        tokenAddress = '0x6A9865aDE2B6207dAAC49f8bCba9705dEB0B0e6D';
+      } else if (document.web3network === 'mainnet') {
+        tokenAddress = '0x6B175474E89094C44Da98b954EedeAC495271d0F';
+      } else {
+        _alert('Unsupported network', 'error');
+        return;
+      }
       const factory = await new web3.eth.Contract(document.contxt.ptoken_factory_abi, factoryAddress);
       const newPToken = this.newPToken;
 
       // Deploy on-chain
+      indicateMetamaskPopup();
       factory.methods.createPToken(
         newPToken.name,
         newPToken.symbol,
-        newPToken.price,
-        newPToken.supply,
-        mockDaiAddress
+        web3.utils.toWei(String(newPToken.price)),
+        web3.utils.toWei(String(newPToken.supply)),
+        tokenAddress
       ).send({
         from: user
       }).on('transactionHash', function(transactionHash) {
@@ -348,7 +366,24 @@ Vue.mixin({
         );
         vm.user_has_token = true;
         console.log('Token Created!');
+      }).on('error', function(err) {
+        this.handleError(err);
       });
+    },
+
+    handleError(err) {
+      console.error(err); // eslint-disable-line no-console
+      let message = 'There was an error';
+
+      if (err.message)
+        message = err.message;
+      else if (err.msg)
+        message = err.msg;
+      else if (typeof err === 'string')
+        message = err;
+
+      _alert(message, 'error');
+      indicateMetamaskPopup(true);
     }
   }
 });

--- a/app/assets/v2/js/pages/profile_tokens.js
+++ b/app/assets/v2/js/pages/profile_tokens.js
@@ -1,5 +1,7 @@
-const factoryAddress = '0x7bE324A085389c82202BEb90D979d097C5b3f2E8';
-const DAI = '0x6b67DD1542ef11153141037734D21E7Cbd7D9817';
+// Personal token constants
+// Note that this address is also duplicated in board.js
+const factoryAddress = '0x80D50970599E33d0D5D436A649C25b729666A015';
+const defaultTokenName = 'DAI';
 
 $(document).on('click', '#submit_buy_token', (event) => {
   event.preventDefault();
@@ -18,7 +20,7 @@ $(document).on('input', '#ptokenRedeemAmount', (event) => {
   event.preventDefault();
   const amount = $(event.target).val();
 
-  $('#ptokenRedeemCost').text(`${document.current_ptoken_value * parseFloat(amount) || 0} DAI`);
+  $('#ptokenRedeemCost').text(`${document.current_ptoken_value * parseFloat(amount) || 0} ${defaultTokenName}`);
   $('#redeem-amount').text(parseFloat(amount));
 });
 
@@ -26,7 +28,7 @@ $(document).on('input', '#ptokenAmount', (event) => {
   event.preventDefault();
   const amount = $(event.target).val();
 
-  $('#ptokenCost').text(`${document.current_ptoken_value * parseFloat(amount) || 0} DAI`);
+  $('#ptokenCost').text(`${document.current_ptoken_value * parseFloat(amount) || 0} ${defaultTokenName}`);
   $('#buy-amount').text(amount);
 });
 
@@ -70,6 +72,8 @@ async function buyPToken(tokenAmount) {
     pTokenAddress // TODO: this needs to be derived from the profile page
   );
 
+  // TODO add token approval step
+
   pToken.methods
     .purchase(tokenAmount)
     .send({
@@ -83,10 +87,12 @@ async function buyPToken(tokenAmount) {
         (new Date()).toISOString(),
         transactionHash
       );
+      // TODO need to confirm that transaction was confirmed. Use web3's getTransactionReceipt
     });
 }
 
 async function redeemPToken(tokenAmount) {
+  // TODO this should be a redemption request with no web3, only DB update
   [user] = await web3.eth.getAccounts();
   const pToken = await new web3.eth.Contract(
     document.contxt.ptoken_abi, // TODO: contxt.ptoken_abi needs to be implemented.
@@ -101,4 +107,5 @@ async function redeemPToken(tokenAmount) {
     .on('transactionHash', function(transactionHash) {
       request_redemption(pTokenId, tokenAmount, network); // TODO: determine token ID and network
     });
+  // TODO need to confirm that transaction was confirmed. Use web3's getTransactionReceipt
 }

--- a/app/assets/v2/js/pages/profile_tokens.js
+++ b/app/assets/v2/js/pages/profile_tokens.js
@@ -1,7 +1,7 @@
 // Personal token constants
 // Note that this address is also duplicated in board.js
 const factoryAddress = '0x80D50970599E33d0D5D436A649C25b729666A015';
-const defaultTokenName = 'DAI';
+const purchaseTokenName = 'DAI';
 
 $(document).on('click', '#submit_buy_token', (event) => {
   event.preventDefault();
@@ -20,7 +20,7 @@ $(document).on('input', '#ptokenRedeemAmount', (event) => {
   event.preventDefault();
   const amount = $(event.target).val();
 
-  $('#ptokenRedeemCost').text(`${document.current_ptoken_value * parseFloat(amount) || 0} ${defaultTokenName}`);
+  $('#ptokenRedeemCost').text(`${document.current_ptoken_value * parseFloat(amount) || 0} ${purchaseTokenName}`);
   $('#redeem-amount').text(parseFloat(amount));
 });
 
@@ -28,7 +28,7 @@ $(document).on('input', '#ptokenAmount', (event) => {
   event.preventDefault();
   const amount = $(event.target).val();
 
-  $('#ptokenCost').text(`${document.current_ptoken_value * parseFloat(amount) || 0} ${defaultTokenName}`);
+  $('#ptokenCost').text(`${document.current_ptoken_value * parseFloat(amount) || 0} ${purchaseTokenName}`);
   $('#buy-amount').text(amount);
 });
 

--- a/app/assets/v2/js/ptokens/ptokens.js
+++ b/app/assets/v2/js/ptokens/ptokens.js
@@ -35,6 +35,7 @@ function create_ptoken(name, symbol, address, value, minted, owner_address, txId
 function update_ptoken_address(tokenId, token_address) {
   return fetchData(`/ptokens/${tokenId}/`, 'POST', {
     'event_name': 'update_address',
+    'tx_status': TX_STATUS_SUCCESS,
     'token_address': token_address
   });
 }

--- a/app/dashboard/templates/board/index.html
+++ b/app/dashboard/templates/board/index.html
@@ -74,6 +74,7 @@
       {% endif %}
     </script>
     <script src="{% static "v2/js/board.js" %}"></script>
+    <script src="{% static "v2/js/tokens.js" %}"></script>
     <script src="{% static "v2/js/ptokens/ptokens.js" %}"></script>
     <script>
       $('body').bootstrapTooltip({

--- a/app/ptokens/views.py
+++ b/app/ptokens/views.py
@@ -96,7 +96,7 @@ def tokens(request, token_state=None):
             error = 'No initial price for token'
         else:
             try:
-                total_minted = float(value)
+                value = float(value)
             except ValueError:
                 error = 'bad format on price value'
         if not txid:


### PR DESCRIPTION
Main changes:
- `factoryAddress` is now set to the Rinkeby pToken factory address
- Updates to `deployAndSaveToken()` to properly handle errors and deployment
- Personal token contract can now be deployed from dashboard

@coopahtroopanew No real UX work was done here, the big one left to do related to this PR is `// TODO: Show loading while deploying`. Did add a call to `indicateMetamaskPopup()` to show the pointer to the browser extension when a tx needs to be confirmed, but I haven't tested how that works with other wallets (hopefully it does nothing, but I'm not sure)