### PR TITLE
After ptoken creation tx is mined, frontend and DB automatically update

### DIFF
--- a/app/app/urls.py
+++ b/app/app/urls.py
@@ -92,6 +92,7 @@ urlpatterns = [
     path('ptokens/<int:tokenId>/', ptokens.views.ptoken, name='token'),
     path('ptokens/<str:token_state>/', ptokens.views.tokens, name='tokens'),
     path('ptokens/', ptokens.views.tokens, name='tokens'),
+    path('ptokens/update', ptokens.views.process_ptokens, name='process_ptokens'),
 
     # kudos
     re_path(r'^kudos/?$', kudos.views.about, name='kudos_main'),

--- a/app/assets/v2/js/ptokens/ptokens.js
+++ b/app/assets/v2/js/ptokens/ptokens.js
@@ -26,6 +26,10 @@ function create_ptoken(name, symbol, address, value, minted, owner_address, txId
   });
 }
 
+function update_ptokens() {
+  return fetchData('/ptokens/update', 'POST');
+}
+
 function update_ptoken_address(tokenId, token_address) {
   return fetchData(`/ptokens/${tokenId}/`, 'POST', {
     'event_name': 'update_address',

--- a/app/ptokens/views.py
+++ b/app/ptokens/views.py
@@ -439,3 +439,26 @@ def ptoken_purchases(request, tokenId):
                 token_holder_profile=request.user.profile
             )]
         })
+
+@csrf_exempt
+def process_ptokens(self):
+    non_terminal_states = ['pending', 'na', 'unknown']
+    for ptoken in PersonalToken.objects.filter(tx_status__in=non_terminal_states):
+        ptoken.update_tx_status()
+        print(f"syncing ptoken / {ptoken.pk} / {ptoken.network}")
+        ptoken.save()
+
+    for purchase in PurchasePToken.objects.filter(tx_status__in=non_terminal_states):
+        purchase.update_tx_status()
+        print(f"syncing purchase / {purchase.pk} / {purchase.network}")
+        purchase.save()
+
+    for redemption in RedemptionToken.objects.filter(tx_status__in=non_terminal_states):
+        redemption.update_tx_status()
+        print(f"syncing ptoken / {redemption.pk} / {redemption.network}")
+        redemption.save()
+
+    return JsonResponse({
+        'status': 200
+    })
+    


### PR DESCRIPTION
This PR enables the frontend to recognize and react to transaction confirmations.

Changes:
- [x] When creating a pToken, after the tx is confirmed the frontend will ping the DB to update 
- [x] When editing a pToken's price, after the tx is confirmed the frontend will ping the DB to update 
- [x] When editing a pToken's quantity, after the tx is confirmed the frontend will ping the DB to update 
- [x] When purchasing a pToken, after the tx is confirmed the frontend will ping the DB to update 
- [x] When redeeming a pToken, after the tx is confirmed the frontend will ping the DB to update 

How it works:
- A new endpoint is triggered once the transaction is mined. This endpoint, `/ptokens/update`, essentially runs the `update_ptoken_tx_status.py` script to update all pTokendatabase entries
- Right now this approach is ok because the DB is small. As the database grows, we may want to update this request to only update the specific token, purchase, or request you are querying