### PR TITLE
Matt QA Fixes

### DIFF
--- a/app/assets/v2/js/board.js
+++ b/app/assets/v2/js/board.js
@@ -441,8 +441,18 @@ Vue.mixin({
       ).send({
         from: user
       }).on('transactionHash', async function(transactionHash) {
-        // Save to database
         indicateMetamaskPopup(true);
+        // Get url of transaction hash
+        const etherscanUrl = document.web3network === 'mainnet'
+        ? `https://etherscan.io/tx/${transactionHash}`
+        : `https://${document.web3network}.etherscan.io/tx/${transactionHash}`;
+
+        // Hide creation modal and show congratulations modal
+        $('#closeCreatePtokenModal').click()
+        $('#showCreationSuccessModal').click()
+        $('#success-tx').prop('href', etherscanUrl);
+
+        // Save to database
         const ptokenReponse = await create_ptoken(
           newPToken.name,
           newPToken.symbol,

--- a/app/assets/v2/js/board.js
+++ b/app/assets/v2/js/board.js
@@ -318,6 +318,7 @@ Vue.mixin({
         let supply = parseFloat(this.pToken.supply);
         let supply_locked = document.ptoken.supply - document.ptoken.available;
         let stopFlow;
+        const handleError = this.handleError;
 
         if (isNaN(price) || price <= 0) {
           this.$set(this.pToken, 'is_invalid_price', true);
@@ -352,7 +353,6 @@ Vue.mixin({
         const { user } = await this.checkWeb3();
         const pTokenId = this.pToken.id;
         const ptoken = await new web3.eth.Contract(document.contxt.ptoken_abi, this.pToken.address);
-        const handleError = this.handleError;
         const updatePtokenStatusinDatabase = this.updatePtokenStatusinDatabase;
 
         // Changing price
@@ -416,7 +416,7 @@ Vue.mixin({
         $('#closeEdit').click();
         this.pToken.deploying = false;
       } catch (error) {
-        console.log(error);
+        handleError(error);
       }
     },
     async deployAndSaveToken() {
@@ -576,7 +576,6 @@ Vue.mixin({
 
     async checkWeb3() {
       if (!web3) {
-        _alert('Please connect a wallet', 'error');
         throw new Error('Please connect a wallet');
       }
       [user] = await web3.eth.getAccounts();
@@ -584,8 +583,7 @@ Vue.mixin({
       if (document.web3network === 'rinkeby' || document.web3network === 'mainnet') {
         purchaseTokenAddress = this.getTokenByName('DAI').addr;
       } else {
-        _alert('Unsupported network', 'error');
-        throw new Error('Please connect a wallet');
+        throw new Error('Unsupported network');
       }
 
       return { user, purchaseTokenAddress };

--- a/app/assets/v2/js/pages/profile_tokens.js
+++ b/app/assets/v2/js/pages/profile_tokens.js
@@ -20,25 +20,25 @@ $(document).on('click', '#submit_buy_token', (event) => {
   $('#ptokenTerms ~ .invalid-feedback').hide();
 
   // Validate form
-    const amount = parseFloat($('#ptokenAmount').val());
+  const amount = parseFloat($('#ptokenAmount').val());
 
   if (isNaN(amount) || amount < 0 || amount > document.current_ptoken_total_available) {
-      $('#ptokenAmount').addClass('is-invalid');
-      $('#ptokenAmount ~ .invalid-feedback').show();
+    $('#ptokenAmount').addClass('is-invalid');
+    $('#ptokenAmount ~ .invalid-feedback').show();
     return;
-    } else {
-      $('#ptokenAmount').removeClass('is-invalid');
-      $('#ptokenAmount ~ .invalid-feedback').hide();
-    }
+  }
+  $('#ptokenAmount').removeClass('is-invalid');
+  $('#ptokenAmount ~ .invalid-feedback').hide();
+    
 
-    if (!$('#ptokenTerms').is(':checked')) {
-      $('#ptokenTerms').addClass('is-invalid');
-      $('#ptokenTerms ~ .invalid-feedback').show();
+  if (!$('#ptokenTerms').is(':checked')) {
+    $('#ptokenTerms').addClass('is-invalid');
+    $('#ptokenTerms ~ .invalid-feedback').show();
     return;
-    } else {
-      $('#ptokenTerms').removeClass('is-invalid');
-      $('#ptokenTerms ~ .invalid-feedback').hide();
-    }
+  }
+  $('#ptokenTerms').removeClass('is-invalid');
+  $('#ptokenTerms ~ .invalid-feedback').hide();
+    
 
   // Form is good, so continue with transaction
   buyPToken($('#ptokenAmount').val());
@@ -118,6 +118,7 @@ function getTokenByName(name) {
 async function buyPToken(tokenAmount) {
   try {
     const network = checkWeb3();
+
     BN = web3.utils.BN;
 
     [user] = await web3.eth.getAccounts();
@@ -147,7 +148,7 @@ async function buyPToken(tokenAmount) {
         .purchase(amount.toString())
         // We hardcode gas limit otherwise web3's `estimateGas` is used and this will show the user
         // that their transaction will fail because the approval tx has not yet been confirmed
-        .send({ from: user, gasLimit: '100000' })
+        .send({ from: user, gasLimit: '300000' })
         .on('transactionHash', function(transactionHash) {
 
           _alert('Saving transaction. Please do not leave this page.', 'success', 5000);
@@ -162,8 +163,9 @@ async function buyPToken(tokenAmount) {
           );
           console.log('Purchase saved as pending transaction in database');
 
-          const successMsg = 'Congratulations, your token purchsae was successful!';
+          const successMsg = 'Congratulations, your token purchase was successful!';
           const errorMsg = 'Oops, something went wrong purchasing the token. Please try again or contact support@gitcoin.co';
+
           updatePtokenStatusinDatabase(transactionHash, successMsg, errorMsg);
 
           waitingState(false);
@@ -215,7 +217,8 @@ async function buyPToken(tokenAmount) {
 
 async function requestPtokenRedemption(tokenAmount, redemptionDescription) {
   try {
-    const network = checkNetwork(); // no web3 transactions are needed to request redemption 
+    const network = checkNetwork(); // no web3 transactions are needed to request redemption
+
     request_redemption(document.current_ptoken_id, tokenAmount, redemptionDescription, network);
     $('#redeemTokenModal').bootstrapModal('hide');
     _alert('Your redemption request was successful! You should hear from the token owner shortly.', 'success');
@@ -263,9 +266,10 @@ function handleError(err) {
  */
 async function updatePtokenStatusinDatabase(transactionHash, successMsg, errorMsg) {
   console.log('Waiting for transaction to be mined...');
-  callFunctionWhenTransactionMined(transactionHash, async () => {
-    console.log("Transaction mined, updating database...");
+  callFunctionWhenTransactionMined(transactionHash, async() => {
+    console.log('Transaction mined, updating database...');
     const res = await update_ptokens(); // update all ptokens in DB
+
     if (res.status === 200) {
       _alert(successMsg, 'success');
       console.log(successMsg);

--- a/app/assets/v2/js/pages/profile_tokens.js
+++ b/app/assets/v2/js/pages/profile_tokens.js
@@ -109,103 +109,106 @@ function getTokenByName(name) {
 }
 
 async function buyPToken(tokenAmount) {
-  await needWalletConnection();
-  BN = web3.utils.BN;
+  try {
+    const network = checkWeb3();
+    BN = web3.utils.BN;
 
-  [user] = await web3.eth.getAccounts();
-  const pToken = await new web3.eth.Contract(
-    document.contxt.ptoken_abi,
-    document.current_ptoken_address
-  );
-  const network = document.web3network;
-  const tokenDetails = getTokenByName('DAI');
-  const tokenContract = new web3.eth.Contract(token_abi, tokenDetails.addr);
-  // To properly handle decimal values, we first convert to Wei and then to a BN instance
-  const token_value = new BN(web3.utils.toWei(String(document.current_ptoken_value)), 10);
-  const amount = new BN(web3.utils.toWei(tokenAmount, 'ether'));
-  // true value = token value * number of requested tokens
-  // We then need to convert from Wei to "undo" the above conversion of token_value to Wei
-  const true_value = new BN(web3.utils.fromWei(amount.mul(token_value)), 10);
-  const allowance = new BN(await getAllowance(document.current_ptoken_address, tokenDetails.addr), 10);
+    [user] = await web3.eth.getAccounts();
+    const pToken = await new web3.eth.Contract(
+      document.contxt.ptoken_abi,
+      document.current_ptoken_address
+    );
+    const tokenDetails = getTokenByName('DAI');
+    const tokenContract = new web3.eth.Contract(token_abi, tokenDetails.addr);
+    // To properly handle decimal values, we first convert to Wei and then to a BN instance
+    const token_value = new BN(web3.utils.toWei(String(document.current_ptoken_value)), 10);
+    const amount = new BN(web3.utils.toWei(tokenAmount, 'ether'));
+    // true value = token value * number of requested tokens
+    // We then need to convert from Wei to "undo" the above conversion of token_value to Wei
+    const true_value = new BN(web3.utils.fromWei(amount.mul(token_value)), 10);
+    const allowance = new BN(await getAllowance(document.current_ptoken_address, tokenDetails.addr), 10);
 
-  const waitingState = (state) => {
-    indicateMetamaskPopup(!state);
-    $('#submit_buy_token').prop('disabled', state);
-    $('#close_buy_token').prop('disabled', state);
-  };
+    const waitingState = (state) => {
+      indicateMetamaskPopup(!state);
+      $('#submit_buy_token').prop('disabled', state);
+      $('#close_buy_token').prop('disabled', state);
+    };
 
-  const purchasePToken = () => {
+    const purchasePToken = () => {
+      waitingState(true);
+      pToken.methods
+        .purchase(amount.toString())
+        // We hardcode gas limit otherwise web3's `estimateGas` is used and this will show the user
+        // that their transaction will fail because the approval tx has not yet been confirmed
+        .send({ from: user, gasLimit: '100000' })
+        .on('transactionHash', function(transactionHash) {
+
+          _alert('Saving transaction. Please do not leave this page.', 'success', 5000);
+          purchase_ptoken(
+            document.current_ptoken_id,
+            tokenAmount,
+            user,
+            (new Date()).toISOString(),
+            transactionHash,
+            network,
+            tokenDetails
+          );
+          console.log('Purchase saved as pending transaction in database');
+
+          const successMsg = 'Congratulations, your token purchsae was successful!';
+          const errorMsg = 'Oops, something went wrong purchasing the token. Please try again or contact support@gitcoin.co';
+          updatePtokenStatusinDatabase(transactionHash, successMsg, errorMsg);
+
+          waitingState(false);
+          $('#buyTokenModal').bootstrapModal('hide');
+          $('#buy_ptoken_modal').bootstrapModal('show');
+          $('#buy-amount').text(tokenAmount);
+          const etherscanUrl = network === 'mainnet'
+            ? `https://etherscan.io/tx/${transactionHash}`
+            : `https://${network}.etherscan.io/tx/${transactionHash}`;
+
+          $('#buy-tx').prop('href', etherscanUrl);
+        }).on('error', (error, receipt) => {
+          waitingState(false);
+          handleError(error);
+        });
+      
+    };
+
+
+    // Check user token balance against token value
+    console.log(`== user allowance balance: ${allowance}`);
+    const userTokenBalance = await tokenContract.methods.balanceOf(user).call({ from: user });
+
+    // Balance is too small, exit checkout flow
+    console.log(`== user token balance: ${userTokenBalance}`);
+    if (new BN(userTokenBalance, 10).lt(true_value)) {
+      _alert(`Insufficient ${tokenDetails.name} balance to complete checkout`, 'error');
+      return;
+    }
+
     waitingState(true);
-    pToken.methods
-      .purchase(amount.toString())
-      // We hardcode gas limit otherwise web3's `estimateGas` is used and this will show the user
-      // that their transaction will fail because the approval tx has not yet been confirmed
-      .send({ from: user, gasLimit: '100000' })
-      .on('transactionHash', function(transactionHash) {
-
-        _alert('Saving transaction. Please do not leave this page.', 'success', 5000);
-        purchase_ptoken(
-          document.current_ptoken_id,
-          tokenAmount,
-          user,
-          (new Date()).toISOString(),
-          transactionHash,
-          network,
-          tokenDetails
-        );
-        console.log('Purchase saved as pending transaction in database');
-
-        const successMsg = 'Congratulations, your token purchsae was successful!';
-        const errorMsg = 'Oops, something went wrong purchasing the token. Please try again or contact support@gitcoin.co';
-        updatePtokenStatusinDatabase(transactionHash, successMsg, errorMsg);
-
-        waitingState(false);
-        $('#buyTokenModal').bootstrapModal('hide');
-        $('#buy_ptoken_modal').bootstrapModal('show');
-        $('#buy-amount').text(tokenAmount);
-        const etherscanUrl = network === 'mainnet'
-          ? `https://etherscan.io/tx/${transactionHash}`
-          : `https://${network}.etherscan.io/tx/${transactionHash}`;
-
-        $('#buy-tx').prop('href', etherscanUrl);
-      }).on('error', (error, receipt) => {
-        waitingState(false);
-        console.log(error);
-      });
-  };
-
-
-  // Check user token balance against token value
-  console.log(`== user allowance balance: ${allowance}`);
-  const userTokenBalance = await tokenContract.methods.balanceOf(user).call({ from: user });
-
-  // Balance is too small, exit checkout flow
-  console.log(`== user token balance: ${userTokenBalance}`);
-  if (new BN(userTokenBalance, 10).lt(true_value)) {
-    _alert(`Insufficient ${tokenDetails.name} balance to complete checkout`, 'error');
-    return;
-  }
-
-  waitingState(true);
-  indicateMetamaskPopup();
-  if (allowance.lt(true_value)) {
-    tokenContract.methods.approve(document.current_ptoken_address, true_value.toString())
-      .send({from: user})
-      .on('transactionHash', function(txHash) {
-        indicateMetamaskPopup(true);
-        purchasePToken();
-      }).on('error', (error, receipt) => {
-        indicateMetamaskPopup(true);
-        console.log(error);
-      });
-  } else {
-    purchasePToken();
+    indicateMetamaskPopup();
+    if (allowance.lt(true_value)) {
+      tokenContract.methods.approve(document.current_ptoken_address, true_value.toString())
+        .send({from: user})
+        .on('transactionHash', function(txHash) {
+          indicateMetamaskPopup(true);
+          purchasePToken();
+        }).on('error', (error, receipt) => {
+          handleError(error);
+        });
+    } else {
+      purchasePToken();
+    }
+  } catch (error) {
+    handleError(error);
   }
 }
 
 async function requestPtokenRedemption(tokenAmount, redemptionDescription) {
   try {
-    const network = checkNetwork();
+    const network = checkNetwork(); // no web3 transactions are needed to request redemption 
 
     request_redemption(document.current_ptoken_id, tokenAmount, redemptionDescription, network);
   } catch (err) {
@@ -221,6 +224,14 @@ function checkNetwork() {
     throw new Error('Please connect a wallet');
   }
   return document.web3network;
+}
+
+function checkWeb3() {
+  if (!web3) {
+    _alert('Please connect a wallet', 'error');
+    throw new Error('Please connect a wallet');
+  }
+  return checkNetwork();
 }
 
 function handleError(err) {

--- a/app/assets/v2/js/pages/profile_tokens.js
+++ b/app/assets/v2/js/pages/profile_tokens.js
@@ -12,15 +12,20 @@ $(document).on('click', '#redeemPTokens', (event) => {
 
 $(document).on('click', '#submit_buy_token', (event) => {
   event.preventDefault();
-  const form = $('#ptokenBuyForm')[0];
 
-  if (form.checkValidity() === false) {
-    event.stopPropagation();
+  // Hide existing validation errors
+  $('#ptokenAmount').removeClass('is-invalid');
+  $('#ptokenAmount ~ .invalid-feedback').hide();
+  $('#ptokenTerms').removeClass('is-invalid');
+  $('#ptokenTerms ~ .invalid-feedback').hide();
+
+  // Validate form
     const amount = parseFloat($('#ptokenAmount').val());
 
-    if (isNaN(amount) || amount < 0) {
+  if (isNaN(amount) || amount < 0 || amount > document.current_ptoken_total_available) {
       $('#ptokenAmount').addClass('is-invalid');
       $('#ptokenAmount ~ .invalid-feedback').show();
+    return;
     } else {
       $('#ptokenAmount').removeClass('is-invalid');
       $('#ptokenAmount ~ .invalid-feedback').hide();
@@ -29,18 +34,13 @@ $(document).on('click', '#submit_buy_token', (event) => {
     if (!$('#ptokenTerms').is(':checked')) {
       $('#ptokenTerms').addClass('is-invalid');
       $('#ptokenTerms ~ .invalid-feedback').show();
+    return;
     } else {
       $('#ptokenTerms').removeClass('is-invalid');
       $('#ptokenTerms ~ .invalid-feedback').hide();
     }
-    return;
-  }
 
-  $('#ptokenAmount').removeClass('is-invalid');
-  $('#ptokenAmount ~ .invalid-feedback').hide();
-  $('#ptokenTerms').removeClass('is-invalid');
-  $('#ptokenTerms ~ .invalid-feedback').hide();
-
+  // Form is good, so continue with transaction
   buyPToken($('#ptokenAmount').val());
 });
 

--- a/app/assets/v2/js/pages/profile_tokens.js
+++ b/app/assets/v2/js/pages/profile_tokens.js
@@ -65,6 +65,7 @@ $(document).on('click', '#submit_redeem_token', (event) => {
   const form = $('#ptokenRedeemForm')[0];
   const amountField = $(form.ptokenRedeemAmount);
   const tos = $(form.ptokenRedeemTerms);
+  const descriptionField = $(form.ptokenRedeemDescription);
   const redeem_amount = parseFloat(amountField.val());
   const redeem_description = $('#ptokenRedeemDescription').val();
 
@@ -90,6 +91,12 @@ $(document).on('click', '#submit_redeem_token', (event) => {
     return;
   }
   amountField.removeClass('is-invalid');
+
+  if (redeem_description.length < 1) {
+    _alert('Please describe what you would like to redeem the token for', 'error', 2000);
+    descriptionField.addClass('is-invalid');
+    return;
+  }
 
   requestPtokenRedemption(redeem_amount, redeem_description);
 });
@@ -209,8 +216,9 @@ async function buyPToken(tokenAmount) {
 async function requestPtokenRedemption(tokenAmount, redemptionDescription) {
   try {
     const network = checkNetwork(); // no web3 transactions are needed to request redemption 
-
     request_redemption(document.current_ptoken_id, tokenAmount, redemptionDescription, network);
+    $('#redeemTokenModal').bootstrapModal('hide');
+    _alert('Your redemption request was successful! You should hear from the token owner shortly.', 'success');
   } catch (err) {
     handleError(err);
   }

--- a/app/dashboard/templates/board/ptokens.html
+++ b/app/dashboard/templates/board/ptokens.html
@@ -53,6 +53,7 @@
               <div>
                 Create a personal token to get paid today for work tomorrow <a href="{% url 'ptoken_quickstart' %}" class="underline">Learn more</a>
               </div>
+              <div id="showCreationSuccessModal" hidden data-toggle="modal" data-target="#createTokenSuccessModal"></div>
               <button class="btn btn-sm btn-outline-gc-blue m-2" data-toggle="modal" data-target="#createTokenModal">
                 Create
               </button>
@@ -293,5 +294,6 @@
   </section>
 
   {% include 'shared/create_ptoken.html' %}
+  {% include 'shared/create_ptoken_success.html' %}
   {% include 'shared/edit_ptoken.html' %}
 </div>

--- a/app/dashboard/templates/profiles/profile.html
+++ b/app/dashboard/templates/profiles/profile.html
@@ -141,6 +141,7 @@
         document.current_ptoken_symbol = "{{ ptoken.token_symbol }}";
         document.current_ptoken_id = {{ ptoken.id }};
         document.current_ptoken_value = {{ ptoken.value }};
+        document.current_ptoken_total_available = {{ ptoken.total_available }};
         document.current_hodling = {{ current_hodling }};
       {% endif %}
     </script>

--- a/app/dashboard/templates/profiles/scorecard_ptoken.html
+++ b/app/dashboard/templates/profiles/scorecard_ptoken.html
@@ -36,7 +36,11 @@
             {% endif %}
           {% else %}
             <button class="btn btn-outline-gc-blue btn-sm flex-grow-1 font-smaller-5" data-toggle="modal" data-target="#buyTokenModal">BUY</button>
-            <button class="btn btn-outline-gc-blue btn-sm flex-grow-1 font-smaller-5" data-toggle="modal" data-target="#redeemTokenModal">REDEEM</button>
+            {% if available_to_redeem == 0  %}
+              <button disabled style="cursor: default; pointer-events: none;" class="btn btn-outline-gc-blue btn-sm flex-grow-1 font-smaller-5" >REDEEM</button>
+            {% else %}
+              <button class="btn btn-outline-gc-blue btn-sm flex-grow-1 font-smaller-5" data-toggle="modal" data-target="#redeemTokenModal">REDEEM</button>
+            {% endif %}
           {% endif %}
         </li>
     </ul>

--- a/app/ptokens/templates/shared/buy_token_modal.html
+++ b/app/ptokens/templates/shared/buy_token_modal.html
@@ -31,7 +31,7 @@
               <input name='ptokenAmount' id="ptokenAmount" class="form__input" type="text" placeholder="10 {{ ptoken.token_symbol }}" required/>
               <br>
               <div class="invalid-feedback">
-                Please provide the ptokens amount
+                Pleae enter a number between 0 and {{ ptoken.total_available }}
               </div>
             </div>
           </div>

--- a/app/ptokens/templates/shared/create_ptoken.html
+++ b/app/ptokens/templates/shared/create_ptoken.html
@@ -99,7 +99,7 @@
             Confirm
           </button>
           <br>
-          <button type="button" class="btn btn-lg btn-outline-gc-blue px-5" data-dismiss="modal">
+          <button id="closeCreatePtokenModal" type="button" class="btn btn-lg btn-outline-gc-blue px-5" data-dismiss="modal">
             Cancel
           </button>
         </div>

--- a/app/ptokens/templates/shared/create_ptoken_success.html
+++ b/app/ptokens/templates/shared/create_ptoken_success.html
@@ -1,0 +1,35 @@
+  <div class="modal fade" id="createTokenSuccessModal" tabindex="-1" role="dialog">
+  <div class="modal-dialog" style="max-width: 576px;" role="document">
+    <div class="modal-content">
+      <form class="modal-body my-4 mx-5 py-3">
+        <button
+          type="button"
+          class="close"
+          data-dismiss="modal"
+          aria-label="Close"
+        >
+          <span aria-hidden="true">&times;</span>
+        </button>
+        <h5 class="modal-title font-weight-semibold text-center mb-5">Congratulations!</h5>
+
+        <div>
+          <div class="text-center mb-4">
+            You just created <span class="font-weight-semibold">[[ newPToken.symbol ]]</span>
+          </div>
+          <div class="text-center mb-4">
+            View the transaction on <a id="success-tx" href="#" target="_blank">Etherscan</a>.
+          </div>
+          <div class="text-center mb-4">
+            Manage incoming requests via your Dashboard.
+          </div>
+        </div>
+
+        <div class="text-center">
+          <button type="button" class="btn btn-lg btn-gc-blue mb-3 px-5" data-dismiss="modal">
+            Close
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
When a task is complete, it will be checked off below. The phrasing used is taken directly from the HackMD document

### Priority issues
- [x] [Create Token] When creating a new Personal Token, the modal should prompt the pending tx notifcation in the top right. *Note: this was already done*
- [x] [Create Token] After creating a personal token, a new modal should replace the Creation Modal.
- [x] [Profile] “Redeem” should be disabled (e.g. greyed out and cannot be clicked) if you do not own tokens. Currently you can click redeem even if you have no tokens.

### Buy pToken Flow
- [x] If wallet isn’t connected to web3, display error to end user to connect wallet first when clicking Buy 
- [x] If user tries to buy more tokens than available, form should throw validation error 

### Redemption Request Flow
- [x] After submitting redemption request, nothing visible happens. Instead, (1) the modal should close automatically, and (2) the user should be notified their request was successful and they should hear back from the pToken owner soon 
- [x] Ensure users can not submit more redemptions than their total balance *Note: this was already done*
- [x] Description field is currently optional, but should be required

### Create pToken Flow
- [x] If you try deploying a pToken and a wallet is not connected, the error message shows up twice
- [x] If you try deploying a pToken and are on the wrong network, the error message it not “Unsupported network” but says “Trying to call a function on a non-contract address” 